### PR TITLE
More file endings, .gitignore add for virtualenv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ production.cfg
 logs/
 venv/
 data/
+env/

--- a/gerblook/gerber.py
+++ b/gerblook/gerber.py
@@ -64,20 +64,20 @@ def guess_layer(path, gerberdir):
   if re.search(r'\.(out|oln|gm1|gbr|gml|gko|gm16|boardoutline\.ger)', filename):
     return 'outline'
 
-  if re.search(r'\.(gbl|sol|bottomlayer\.ger)', filename):
+  if re.search(r'\.(gbl|sol|bot|bottomlayer\.ger)', filename):
     return 'bottom_copper'
-  if re.search(r'\.(gbs|sts|bottomsoldermask\.ger)', filename):
+  if re.search(r'\.(gbs|sts|smb|bottomsoldermask\.ger)', filename):
     return 'bottom_soldermask'
-  if re.search(r'\.(gbo|bottomsilkscreen\.ger)', filename):
+  if re.search(r'\.(gbo|ssb|bottomsilkscreen\.ger)', filename):
     return 'bottom_silkscreen'
   if re.search(r'\.(gbp|bcream\.ger)', filename):
     return 'bottom_paste'
 
-  if re.search(r'\.(gtl|cmp|toplayer\.ger)', filename):
+  if re.search(r'\.(gtl|cmp|top|toplayer\.ger)', filename):
     return 'top_copper'
-  if re.search(r'\.(gts|stc|topsoldermask\.ger)', filename):
+  if re.search(r'\.(gts|stc|smt|topsoldermask\.ger)', filename):
     return 'top_soldermask'
-  if re.search(r'\.(gto|topsilkscreen\.ger)', filename):
+  if re.search(r'\.(gto|sst|topsilkscreen\.ger)', filename):
     return 'top_silkscreen'
   if re.search(r'\.(gtp|tcream\.ger)', filename):
     return 'top_paste'
@@ -288,4 +288,3 @@ def approx_gerber_size(filename, units=None):
   if units == "inch":
     return (w / 10000.0, h / 10000.0)
   return (w, h)
-

--- a/gerblook/templates/faq.html
+++ b/gerblook/templates/faq.html
@@ -23,22 +23,22 @@
       <dd>*.out *.oln *.gm1 *.gbr *.gml *.gko *.gm16</dd>
 
       <dt>Top Copper (required)</dt>
-      <dd>*.gtl</dd>
+      <dd>*.gtl (*.cmp, *.top, *toplayer*.ger)</dd>
 
       <dt>Bottom Copper (required)</dt>
-      <dd>*.gbl</dd>
+      <dd>*.gbl (*.sol, *.bot, *bottomlayer*.ger)</dd>
 
       <dt>Top Soldermask (required)</dt>
-      <dd>*.gts</dd>
+      <dd>*.gts (*.stc, *.smt, *topsoldermask*.ger)</dd>
 
       <dt>Bottom Soldermask (required)</dt>
-      <dd>*.gbs</dd>
+      <dd>*.gbs (*.sts, *.smb, *bottomsoldermask*.ger)</dd>
 
       <dt>Top Silkscreen</dt>
-      <dd>*.gto</dd>
+      <dd>*.gto (*.sst, *topsilkscreen*.ger)</dd>
 
       <dt>Bottom Silkscreen</dt>
-      <dd>*.gbo</dd>
+      <dd>*.gbo (*.ssb, *bottomsilkscreen*.ger)</dd>
 
       <dt>Plated Drills</dt>
       <dd>*.dri *.drl *.drd *.txt</dd>
@@ -67,8 +67,7 @@
       <dt>Inner Copper 7</dt>
       <dd>*.g7 *.gl7</dd>
     </dl>
-    There are also various other rules to try and fuzzy match based on the contents of the filename but if you stick to the above you should be fine.
+    The * stands for any string of characters. There are also various other rules to try and fuzzy match based on the contents of the filename but if you stick to the above you should be fine.
   </dd>
 </dl>
 {% endblock %}
-


### PR DESCRIPTION
Added more file type endings for automatic mapping, primarily used by
Orcad exports but can be seen a lot. Also updated the FAQ to show that
these endings are supported.

Furthermore added `env/` to .gitignore since it is commonly used vor
virtualenv.
